### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: form.pdf
 
 %.pdf: %.svg
-	inkscape -o $@ $<
+	inkscape --export-filename $@ $<
 
 form.pdf: form.tex style/assets style/assets/logo-text.pdf
 	pdflatex $<

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 all: form.pdf
 
 %.pdf: %.svg
-	inkscape -A $@ $<
+	inkscape -o $@ $<
 
 form.pdf: form.tex style/assets style/assets/logo-text.pdf
 	pdflatex $<


### PR DESCRIPTION
Inkscape 1.1.1 doesn't accept -A as an argument 

I'm not entirely sure of the original intention of the -A, so I can't be 100% sure that -o is the best replacement. But I can say it works